### PR TITLE
Update types to work with new Storybook types

### DIFF
--- a/packages/muban-storybook/README.md
+++ b/packages/muban-storybook/README.md
@@ -15,6 +15,18 @@ The only differences in `muban-storybook` are:
 - How to define your story function
 - How the component is rendered in the preview iframe
 
+## Versions
+
+`@muban/storybook` tries to keep in sync with `@storybook/core`. Whenever we can, it will retain some backwards 
+compatibility for the runtime API. In some case though, the definitions change in a way this is not possible.
+
+The list below helps to see what version of storybook is included, so what features can be used inside your project. 
+
+| @muban/storybook | @storybook/core |
+|------------------|-----------------|
+| `7.0.0-alpha.16` | `6.4.9`         |
+| `7.0.0-alpha.15` | `6.1.21`        |
+
 ## Getting started
 
 Install this package in your project:

--- a/packages/muban-storybook/package.json
+++ b/packages/muban-storybook/package.json
@@ -79,6 +79,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "sort-package-json": "^1.44.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.5.3"
   }
 }

--- a/packages/muban-storybook/src/client/preview/index.ts
+++ b/packages/muban-storybook/src/client/preview/index.ts
@@ -26,10 +26,10 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 };
 
 export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
-export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
-export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
+export const addDecorator = api.clientApi.addDecorator as ClientApi['addDecorator'];
+export const addParameters = api.clientApi.addParameters as ClientApi['addParameters'];
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
 export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;
 export const forceReRender: ClientApi['forceReRender'] = api.forceReRender;
-export const getStorybook: ClientApi['getStorybook'] = api.clientApi.getStorybook;
+export const getStorybook = api.clientApi.getStorybook as ClientApi['getStorybook'];
 export const raw: ClientApi['raw'] = api.clientApi.raw;

--- a/packages/muban-storybook/src/client/preview/render.ts
+++ b/packages/muban-storybook/src/client/preview/render.ts
@@ -1,17 +1,18 @@
 /* eslint-disable no-restricted-properties,@typescript-eslint/no-explicit-any */
 import { createApp } from '@muban/muban';
 import { document } from 'global';
-import type { RenderContext, StoryFnMubanReturnType } from './types';
+import type { MubanFramework, RenderContext, StoryFnMubanReturnType } from './types';
 
 const rootElement = document.querySelector('#root');
 
-export default function renderMain(options: RenderContext): void {
+export default function renderMain(options: RenderContext<MubanFramework>): void {
   const {
     storyFn,
     showMain,
   } = options;
 
-  const args = options.storyContext.args || options.args;
+  // backwards compatibility in types
+  const args = options.storyContext.args || (options as any).args;
 
   const componentStory = storyFn(args as any) as StoryFnMubanReturnType;
   showMain();

--- a/packages/muban-storybook/src/client/preview/types.ts
+++ b/packages/muban-storybook/src/client/preview/types.ts
@@ -9,6 +9,11 @@ export interface ShowErrorArgs {
   description: string;
 }
 
+export type MubanFramework = {
+  component: any;
+  storyResult: StoryFnMubanReturnType;
+};
+
 export type StoryFnMubanReturnType = {
   component?: ComponentFactory<any>;
   template: ComponentTemplate;

--- a/packages/muban-storybook/src/client/preview/utils.ts
+++ b/packages/muban-storybook/src/client/preview/utils.ts
@@ -1,5 +1,5 @@
 import { ComponentTemplateResult, html } from '@muban/template';
-import type { StoryContext } from '@storybook/addons/dist/types';
+import type { StoryContext } from '@storybook/addons';
 import type { StoryFnMubanReturnType } from './types';
 
 type StoryFn = () => StoryFnMubanReturnType;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11678,6 +11678,11 @@ typescript@^4.0.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
   integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
+typescript@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
+  integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
+
 uglify-js@^3.1.4:
   version "3.11.6"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.6.tgz#144b50d3e05eadd3ad4dd047c60ca541a8cd4e9c"


### PR DESCRIPTION
Last commit/PR updated the Storybook types, but some issues remained.
When updating TS to 4.5, even more showed up (related to unknown type as
default in generics).

This change seems to fix the issue, but might not work properly for
older storybook versions anymore.