### PR TITLE
Unwrap storyTemplateResult from unsafeHTML

### DIFF
--- a/packages/muban-storybook/src/client/preview/utils.ts
+++ b/packages/muban-storybook/src/client/preview/utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/prevent-abbreviations */
-import { ComponentTemplateResult, html, unsafeHTML } from '@muban/template';
+import { ComponentTemplateResult, html } from '@muban/template';
 import type { DecoratorFunction, StoryContext } from '@storybook/csf';
 import type { StoryFnMubanReturnType } from './types';
 import type { MubanFramework } from './types-6-0';
@@ -50,7 +50,7 @@ export function createDecoratorComponent<Args>(
     if (!decoratorComponent.template && decoratorComponent.component) {
       template = (): string | Array<string> =>
         html`<div data-component=${decoratorComponent.component!.displayName}>
-          ${unsafeHTML(storyTemplateResult.toString())}
+          ${storyTemplateResult}
         </div>`;
     }
 


### PR DESCRIPTION
We shouldn't change markup generated by `storyComponent.template(...)`
because components already return safe HTML (using the html template
literal).

#6