### PR TITLE
Change server rendering to be more explicit, and support decorators

### DIFF
--- a/packages/example/.storybook/preview.js
+++ b/packages/example/.storybook/preview.js
@@ -8,14 +8,14 @@ export const parameters = {
 
 // add global var to control server rendering
 export const globalTypes = {
-  serverRendering: {
-    name: 'Server',
-    description: 'Server Rendering',
-    defaultValue: 'allowed',
+  renderMode: {
+    name: 'Render Mode',
+    description: 'Render template on the server or client',
+    defaultValue: 'client',
     toolbar: {
       icon: 'transfer',
       // Array of plain string values or MenuItem shape (see below)
-      items: ['allowed', 'disabled'],
+      items: ['client', 'server'],
       // Property that specifies if the name of the item will be displayed
       // showName: true,
       // Change title based on selected value

--- a/packages/example/src/Server.stories.ts
+++ b/packages/example/src/Server.stories.ts
@@ -1,4 +1,6 @@
 import type { TemplateStoryProps, Story, Meta } from '@muban/storybook';
+import { createDecoratorComponent } from '@muban/storybook';
+import { html } from '@muban/template';
 import { StoryComponent, storyTemplate } from './Component';
 import { argTypes } from './StoryComponent.argTypes';
 
@@ -6,14 +8,52 @@ export default {
   title: 'Server',
   component: StoryComponent,
   argTypes,
-} as Meta;
-
-// Render on the server!
-export const Simple: Story<TemplateStoryProps<typeof storyTemplate>> = {
   parameters: {
     server: {
       id: 'useToggle',
     },
+  },
+} as Meta;
+
+const addBorder = createDecoratorComponent(({ template }) => ({
+  template: () => html`<div style="border: 1px solid red">${template}</div>`,
+}));
+
+// Render on the server!
+export const Simple: Story<TemplateStoryProps<typeof storyTemplate>> = {
+  args: {
+    initialValue: true,
+  },
+};
+
+export const SimpleWithDecorator: Story<TemplateStoryProps<typeof storyTemplate>> = {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  decorators: [addBorder],
+  args: {
+    initialValue: true,
+  },
+};
+
+export const ClientTemplate: Story<TemplateStoryProps<typeof storyTemplate>> = {
+  render() {
+    return {
+      template: () => html`<div>client-rendering</div>`,
+    };
+  },
+  args: {
+    initialValue: true,
+  },
+};
+
+export const ClientTemplateWithDecorator: Story<TemplateStoryProps<typeof storyTemplate>> = {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  decorators: [addBorder],
+  render() {
+    return {
+      template: () => html`<div>client-rendering</div>`,
+    };
   },
   args: {
     initialValue: true,

--- a/packages/muban-storybook/src/client/preview/utils.ts
+++ b/packages/muban-storybook/src/client/preview/utils.ts
@@ -21,7 +21,14 @@ export function createDecoratorComponent<Args>(
 ): DecoratorFunction<MubanFramework, Args> {
   return (story, context) => {
     const storyComponent = story();
-    const storyTemplateResult = storyComponent.template(context.args ?? {});
+    let storyTemplateResult = storyComponent.template(context.args ?? {});
+
+    // If we are currently rendering on the server, we inject a __PLACEHOLDER__ when our story is empty.
+    // This allows us to identify where to inject our server-rendered story inside the decorators.
+    if (context.globals.renderMode === 'server') {
+      storyTemplateResult ||= '__PLACEHOLDER__';
+    }
+
     const decoratorComponent = createDecoratorFn({
       story,
       context,


### PR DESCRIPTION
change the `globals` to make server rendering more explicit, and fall back to only render if server information is provided (like initially).

With server rendering being more explicit, its state can be used in other code to act on the renderMode, including providing inject placeholders for decorators in stories without local templates.