### PR TITLE
Ignore undefined values when processing story args

### DIFF
--- a/packages/muban-storybook/src/client/preview/utils/getTemplateArgs.test.ts
+++ b/packages/muban-storybook/src/client/preview/utils/getTemplateArgs.test.ts
@@ -1,0 +1,39 @@
+import { processStoryArgs } from './getTemplateArgs';
+
+describe('getTemplateArgs', () => {
+  describe('processStoryArgs', () => {
+    it('should return an empty object for an empty input object', () => {
+      expect(processStoryArgs({}, {}, {})).toEqual({});
+    });
+
+    it('should convert boolean strings to booleans', () => {
+      expect(
+        processStoryArgs(
+          { someBooleanAttribute: 'true' },
+          { someBooleanAttribute: { control: 'boolean' } },
+          { boolean: (value: unknown): boolean => value === true || value === 'true' },
+        ),
+      ).toEqual({ someBooleanAttribute: true });
+    });
+
+    it('should ignore undefined values', () => {
+      expect(
+        processStoryArgs(
+          { someBooleanAttribute: undefined },
+          { someBooleanAttribute: { control: 'boolean' } },
+          { boolean: (value: unknown): boolean => value === true || value === 'true' },
+        ),
+      ).toEqual({});
+    });
+
+    it('should delete action values', () => {
+      expect(
+        processStoryArgs(
+          { someActionAttribute: 'foo' },
+          { someActionAttribute: { action: 'foo' } },
+          { action: 'delete' },
+        ),
+      ).toEqual({});
+    });
+  });
+});

--- a/packages/muban-storybook/src/client/preview/utils/getTemplateArgs.ts
+++ b/packages/muban-storybook/src/client/preview/utils/getTemplateArgs.ts
@@ -9,6 +9,10 @@ export function processStoryArgs(
   const storyArguments = { ...args };
 
   for (const key of Object.keys(argumentTypes)) {
+    if (storyArguments[key] === undefined) {
+      continue;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const argumentType = argumentTypes[key]!;
     const { control, action } = argumentType;


### PR DESCRIPTION
`undefined` `booleans` should not be converted to `false`, which was happening previously.