### PR TITLE
Add a rule check to add additional loaders to preset rules

### DIFF
--- a/packages/preset-webpack/src/index.ts
+++ b/packages/preset-webpack/src/index.ts
@@ -3,16 +3,23 @@ import type { StorybookConfig } from './types.js';
 export * from './types.js';
 
 export const webpack: StorybookConfig['webpack'] = (config) => {
-  config.module?.rules?.[2].use.push({
-    loader: 'ts-loader',
-    options: {
-      // makes sure to load only the files required by webpack and nothing more
-      onlyCompileBundledFiles: true,
-      // type checking is handled by `fork-ts-checker-webpack-plugin`
-      transpileOnly: true,
-      happyPackMode: true,
-    },
-  });
+  if (config.module?.rules) {
+    config.module.rules = config.module.rules.map((rule) => {
+      if (rule.test?.toString().includes('tsx?') && rule.use && Array.isArray(rule.use)) {
+        rule.use.push({
+          loader: 'ts-loader',
+          options: {
+            // makes sure to load only the files required by webpack and nothing more
+            onlyCompileBundledFiles: true,
+            // type checking is handled by `fork-ts-checker-webpack-plugin`
+            transpileOnly: true,
+            happyPackMode: true,
+          },
+        });
+      }
+      return rule;
+    });
+  }
 
   return config;
 };


### PR DESCRIPTION
Add a rule check to make sure additional loaders are being pushed to the correct rule instead of hardcoding a specific index. Matchers are extracted from the current preset configurations:
```javascript
[
  { test: /\.m?js$/, type: 'javascript/auto' },
  { test: /\.m?js$/, resolve: { fullySpecified: false } },
  {
    test: /\.(mjs|tsx?|jsx?)$/, // <-- Target rule
    use: [ [Object] ],
    include: [ '/Volumes/Proyects/muban-storybook' ],
    exclude: /node_modules/
  },
  { test: /\.md$/, type: 'asset/source' }
]
```